### PR TITLE
Android arch component

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,5 +78,8 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-inline:2.11.0'
+
+
+    implementation "android.arch.lifecycle:extensions:1.0.0"
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -78,5 +78,7 @@ dependencies {
 
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-inline:2.11.0'
+
+    implementation "android.arch.lifecycle:extensions:1.0.0"
 }
 

--- a/app/src/main/java/uk/co/mycompany/di/ActivityBuilder.kt
+++ b/app/src/main/java/uk/co/mycompany/di/ActivityBuilder.kt
@@ -3,11 +3,10 @@ package uk.co.mycompany.di
 import dagger.Module
 import dagger.android.ContributesAndroidInjector
 import uk.co.mycompany.ui.main.MainActivity
-import uk.co.mycompany.ui.main.di.MainActivityModule
 
 @Module
 abstract class ActivityBuilder {
 
-    @ContributesAndroidInjector(modules = arrayOf(MainActivityModule::class))
+    @ContributesAndroidInjector
     abstract fun bindMainActivity(): MainActivity
 }

--- a/app/src/main/java/uk/co/mycompany/di/AppModule.kt
+++ b/app/src/main/java/uk/co/mycompany/di/AppModule.kt
@@ -15,13 +15,14 @@ import okhttp3.logging.HttpLoggingInterceptor
 import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 import uk.co.mycompany.api.ApiService
+import uk.co.mycompany.ui.main.di.ViewModelModule
 import uk.co.mycompany.util.SchedulerProvider
 import java.io.File
 import java.util.*
 import java.util.concurrent.TimeUnit
 import javax.inject.Singleton
 
-@Module
+@Module(includes = arrayOf(ViewModelModule::class))
 class AppModule {
 
     @Provides

--- a/app/src/main/java/uk/co/mycompany/ui/main/MainActivity.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/MainActivity.kt
@@ -1,29 +1,45 @@
 package uk.co.mycompany.ui.main
 
+import android.app.Fragment
+import android.arch.lifecycle.ViewModelProvider
+import android.arch.lifecycle.ViewModelProviders
 import android.os.Bundle
+import android.support.v7.app.AppCompatActivity
 import android.util.Log
-import dagger.android.DaggerActivity
+import dagger.android.*
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.rxkotlin.subscribeBy
+import kotlinx.android.synthetic.main.activity_main.*
 
 import uk.co.mycompany.R
 import javax.inject.Inject
 
-class MainActivity: DaggerActivity() {
+class MainActivity: AppCompatActivity(), HasFragmentInjector {
+
+    @Inject lateinit var fragmentInjector: DispatchingAndroidInjector<Fragment>
+
+    override fun fragmentInjector(): AndroidInjector<Fragment> {
+        return fragmentInjector
+    }
 
     private val compositeDisposable by lazy { CompositeDisposable() }
 
-    @Inject lateinit var mainActivityViewModel: MainActivityViewModel
+    lateinit var mainActivityViewModel: MainActivityViewModel
+    @Inject lateinit var viewModelFactory: ViewModelFactory
 
     override fun onCreate(savedInstanceState: Bundle?) {
+        AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
+        mainActivityViewModel = ViewModelProviders.of(this, viewModelFactory).get(MainActivityViewModel::class.java)
 
         compositeDisposable.add(mainActivityViewModel.showDataFromApi()
                 .subscribeBy(onSuccess = {
                     Log.d("MainActivity", it.ip)
+                    tv.text = it.ip
                 }, onError = {
                     Log.d("MainActivity", it.message)
+                    tv.text = it.message
                 }))
     }
 

--- a/app/src/main/java/uk/co/mycompany/ui/main/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/MainActivityViewModel.kt
@@ -1,11 +1,14 @@
 package uk.co.mycompany.ui.main
 
+import android.arch.lifecycle.ViewModel
 import io.reactivex.Single
 import uk.co.mycompany.api.model.IpAddress
 import uk.co.mycompany.repository.Repository
 import uk.co.mycompany.util.SchedulerProvider
+import javax.inject.Inject
 
-class MainActivityViewModel(private val repository: Repository, private val schedulerProvider: SchedulerProvider) {
+open class MainActivityViewModel
+@Inject constructor(private val repository: Repository, private val schedulerProvider: SchedulerProvider) :ViewModel(){
 
     fun showDataFromApi(): Single<IpAddress> = repository.getDataFromApi()
             .compose(schedulerProvider.getSchedulersForSingle())

--- a/app/src/main/java/uk/co/mycompany/ui/main/MainActivityViewModel.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/MainActivityViewModel.kt
@@ -1,11 +1,12 @@
 package uk.co.mycompany.ui.main
 
+import android.arch.lifecycle.ViewModel
 import io.reactivex.Single
 import uk.co.mycompany.api.model.IpAddress
 import uk.co.mycompany.repository.Repository
 import uk.co.mycompany.util.SchedulerProvider
 
-class MainActivityViewModel(private val repository: Repository, private val schedulerProvider: SchedulerProvider) {
+class MainActivityViewModel(private val repository: Repository, private val schedulerProvider: SchedulerProvider) : ViewModel(){
 
     fun showDataFromApi(): Single<IpAddress> = repository.getDataFromApi()
             .compose(schedulerProvider.getSchedulersForSingle())

--- a/app/src/main/java/uk/co/mycompany/ui/main/ViewModelFactory.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/ViewModelFactory.kt
@@ -1,0 +1,45 @@
+package uk.co.mycompany.ui.main
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+@Singleton
+class ViewModelFactory @Inject
+constructor(private val creators: Map<Class<out ViewModel>, Provider<ViewModel>>) : ViewModelProvider.Factory {
+
+    init {
+        Log.d(TAG, "ViewModelFactory: ")
+    }
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        var creator: Provider<out ViewModel>? = creators[modelClass]
+        if (creator == null) {
+            for ((key, value) in creators) {
+                if (modelClass.isAssignableFrom(key)) {
+                    creator = value
+                    break
+                }
+            }
+        }
+        if (creator == null) {
+            throw IllegalArgumentException("unknown model class " + modelClass)
+        }
+        try {
+            return creator.get() as T
+        } catch (e: Exception) {
+            throw RuntimeException(e)
+        }
+
+    }
+
+    companion object {
+        private val TAG = "ViewModelFactory"
+    }
+}

--- a/app/src/main/java/uk/co/mycompany/ui/main/ViewModelFactory.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/ViewModelFactory.kt
@@ -1,0 +1,45 @@
+package uk.co.mycompany.ui.main
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import android.util.Log
+import javax.inject.Inject
+import javax.inject.Provider
+import javax.inject.Singleton
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+@Singleton
+open class ViewModelFactory
+@Inject constructor(private val creators: Map<Class<out ViewModel>, @JvmSuppressWildcards Provider<ViewModel>>) : ViewModelProvider.Factory {
+
+    init {
+        Log.d(TAG, "ViewModelFactory: ")
+    }
+
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        var creator: Provider<out ViewModel>? = creators[modelClass]
+        if (creator == null) {
+            for ((key, value) in creators) {
+                if (modelClass.isAssignableFrom(key)) {
+                    creator = value
+                    break
+                }
+            }
+        }
+        if (creator == null) {
+            throw IllegalArgumentException("unknown model class " + modelClass)
+        }
+        try {
+            return creator.get() as T
+        } catch (e: Exception) {
+            throw RuntimeException(e)
+        }
+
+    }
+
+    companion object {
+        private val TAG = "ViewModelFactory"
+    }
+}

--- a/app/src/main/java/uk/co/mycompany/ui/main/ViewModelKey.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/ViewModelKey.kt
@@ -1,0 +1,16 @@
+package uk.co.mycompany.ui.main
+
+import android.arch.lifecycle.ViewModel
+
+import dagger.MapKey
+import kotlin.annotation.Retention
+import kotlin.reflect.KClass
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+@MustBeDocumented
+@Target(AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@MapKey
+annotation class ViewModelKey(val value: KClass<out ViewModel>)

--- a/app/src/main/java/uk/co/mycompany/ui/main/di/MainActivityModule.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/di/MainActivityModule.kt
@@ -8,7 +8,6 @@ import uk.co.mycompany.util.SchedulerProvider
 
 @Module
 class MainActivityModule {
-
     @Provides
     fun provideViewModel(repository: Repository, schedulerProvider: SchedulerProvider) = MainActivityViewModel(repository, schedulerProvider)
 }

--- a/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelKey.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelKey.kt
@@ -1,0 +1,18 @@
+package uk.co.mycompany.ui.main.di
+
+import android.arch.lifecycle.ViewModel
+import dagger.MapKey
+import java.lang.annotation.*
+import java.lang.annotation.Retention
+import kotlin.annotation.AnnotationTarget.FUNCTION
+import kotlin.reflect.KClass
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+
+@Documented
+@Target(FUNCTION)
+@Retention(RetentionPolicy.RUNTIME)
+@MapKey
+annotation class ViewModelKey(val value: KClass<out ViewModel>)

--- a/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelModule.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelModule.kt
@@ -1,0 +1,25 @@
+package uk.co.mycompany.ui.main.di
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import dagger.Binds
+import dagger.Module
+import dagger.multibindings.IntoMap
+import uk.co.mycompany.ui.main.MainActivityViewModel
+import uk.co.mycompany.ui.main.ViewModelFactory
+import uk.co.mycompany.ui.main.ViewModelKey
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+@Module
+open abstract class ViewModelModule {
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(MainActivityViewModel::class)
+    abstract fun bindsMainViewModel(mainActivityViewModel: MainActivityViewModel): ViewModel
+
+    @Binds
+    abstract fun bindsViewModelFactory(viewModelFactory: ViewModelFactory): ViewModelProvider.Factory
+}

--- a/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelModule.kt
+++ b/app/src/main/java/uk/co/mycompany/ui/main/di/ViewModelModule.kt
@@ -1,0 +1,22 @@
+package uk.co.mycompany.ui.main.di
+
+import android.arch.lifecycle.ViewModel
+import android.arch.lifecycle.ViewModelProvider
+import dagger.Binds
+import dagger.multibindings.IntoMap
+import uk.co.mycompany.ui.main.MainActivityViewModel
+import uk.co.mycompany.ui.main.ViewModelFactory
+
+/**
+ * Created by Md. Sifat-Ul Haque on 1/29/2018.
+ */
+abstract class ViewModelModule {
+
+    @Binds
+    @IntoMap
+    @ViewModelKey(MainActivityViewModel::class)
+    internal abstract fun bindsMainActivityViewModel(mainActivityViewModel: MainActivityViewModel): ViewModel
+
+    @Binds
+    internal abstract fun bindsViewModelFactory(viewModelFactory: ViewModelFactory): ViewModelProvider.Factory
+}

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,6 +7,7 @@
     tools:context="uk.co.mycompany.ui.main.MainActivity">
 
     <TextView
+        android:gravity="center"
         android:id="@+id/tv"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"


### PR DESCRIPTION
Android architecture component (`ViewModel`) has been integrated with the existing project.  As `DaggerActivity` extends from `Activity` and `ViewModelProviders.of()` method requires a `Fragment` or `FragmentActivity` as it's first parameter, The parent of `MainActivity` has been changed to `AppCompatActivity` from `DaggerActivity` and addition modifications have been made because of this change.